### PR TITLE
Add Loki and Alloy to stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This is a work-in-progress [FluxCD](https://fluxcd.io/) repository to bring up c
 ```
 .
 ├── applications
-│   ├── loki
-│   └── kube-prometheus-stack
+│   ├── alloy
+│   ├── kube-prometheus-stack
+│   └── loki
 ├── clusters
 │   ├── azure
 │   │   └── production
@@ -26,6 +27,7 @@ This is a work-in-progress [FluxCD](https://fluxcd.io/) repository to bring up c
 │           └── flux-system
 ├── infrastructure
 │   ├── dashboards
+│   ├── logs
 │   └── monitors
 └── scripts
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a work-in-progress [FluxCD](https://fluxcd.io/) repository to bring up c
 ```
 .
 ├── applications
+│   ├── loki
 │   └── kube-prometheus-stack
 ├── clusters
 │   ├── azure

--- a/applications/alloy/kustomization.yaml
+++ b/applications/alloy/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - logs.yaml
+  - release.yaml

--- a/applications/alloy/logs.yaml
+++ b/applications/alloy/logs.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: logs-sync
+  namespace: monitoring
+spec:
+  interval: 1m
+  path: ./infrastructure/logs
+  prune: true
+  dependsOn:
+    - name: monitoring-sync
+      namespace: monitoring
+  sourceRef:
+    kind: GitRepository
+    name: monitoring-flux-infra
+    namespace: flux-system

--- a/applications/alloy/release.yaml
+++ b/applications/alloy/release.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: alloy
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+      version: "1.1.2"
+  interval: 10m
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  valuesFrom:
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: alloy-values.yaml

--- a/applications/alloy/values.yaml
+++ b/applications/alloy/values.yaml
@@ -1,0 +1,16 @@
+# https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml
+alloy:
+  configMap:
+    create: false
+    name: logs
+    key: base.alloy
+  envFrom:
+  - configMapRef:
+      name: logs
+controller:
+  type: 'daemonset'
+  replicas: 1
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack

--- a/applications/kube-prometheus-stack/release.yaml
+++ b/applications/kube-prometheus-stack/release.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
@@ -24,11 +25,11 @@ spec:
         target:
           kind: PrometheusRule
   valuesFrom:
-  # Shared/base values for monitoring applications
-  - kind: ConfigMap
-    name: base-values
-    valuesKey: kube-prometheus-stack-values.yaml
-  # Additional configuration for dashboards, metrics, or infrastructure
-  - kind: ConfigMap
-    name: base-config
-    valuesKey: kube-state-metrics-config.yaml
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: kube-prometheus-stack-values.yaml
+    # Additional configuration for dashboards, metrics, or infrastructure
+    - kind: ConfigMap
+      name: base-config
+      valuesKey: kube-state-metrics-config.yaml

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -25,7 +25,8 @@ grafana:
   additionalDataSources:
     - name: Loki
       type: loki
-      url: http://loki-gateway.loki
+      url: http://loki-gateway.monitoring
+      # url: http://loki-gateway.{{ template "loki.namespace" . }}.svc.cluster.local:{{ .Values.gateway.service.port }}
       access: proxy
       isDefault: false
       jsonData:

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -25,8 +25,7 @@ grafana:
   additionalDataSources:
     - name: Loki
       type: loki
-      url: http://loki-gateway.monitoring
-      # url: http://loki-gateway.{{ template "loki.namespace" . }}.svc.cluster.local:{{ .Values.gateway.service.port }}
+      url: http://loki-gateway.{{ template "loki.namespace" . }}
       access: proxy
       isDefault: false
       jsonData:

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -25,7 +25,7 @@ grafana:
   additionalDataSources:
     - name: Loki
       type: loki
-      url: http://{{ template "loki.fullname" . }}.{{ .loki.namespace }}.svc.cluster.local:3100
+      url: http://loki-gateway.loki
       access: proxy
       isDefault: false
       jsonData:

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -25,7 +25,7 @@ grafana:
   additionalDataSources:
     - name: Loki
       type: loki
-      url: http://loki-gateway.{{ template "loki.namespace" . }}
+      url: http://loki-gateway.monitoring
       access: proxy
       isDefault: false
       jsonData:

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -29,7 +29,7 @@ grafana:
       access: proxy
       isDefault: false
       jsonData:
-      maxLines: 1000
+        maxLines: 1000
     - name: "Prometheus AlertManager"
       type: camptocamp-prometheus-alertmanager-datasource
       uid: prometheus-alertmanager

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -23,13 +23,13 @@ prometheus:
     namespace: monitoring
 grafana:
   additionalDataSources:
-    # - name: Loki
-    #   type: loki
-    #   url: http://loki-gateway.loki
-    #   access: proxy
-    #   isDefault: false
-    #   jsonData:
-    #     maxLines: 1000
+    - name: Loki
+      type: loki
+      url: http://loki-gateway.loki
+      access: proxy
+      isDefault: false
+      jsonData:
+        maxLines: 1000
     - name: "Prometheus AlertManager"
       type: camptocamp-prometheus-alertmanager-datasource
       uid: prometheus-alertmanager

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -29,7 +29,7 @@ grafana:
       access: proxy
       isDefault: false
       jsonData:
-        maxLines: 1000
+      maxLines: 1000
     - name: "Prometheus AlertManager"
       type: camptocamp-prometheus-alertmanager-datasource
       uid: prometheus-alertmanager

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -25,7 +25,7 @@ grafana:
   additionalDataSources:
     - name: Loki
       type: loki
-      url: http://loki-gateway.loki
+      url: http://{{ template "loki.fullname" . }}.{{ .loki.namespace }}.svc.cluster.local:3100
       access: proxy
       isDefault: false
       jsonData:

--- a/applications/kustomization.yaml
+++ b/applications/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: monitoring
 configMapGenerator:
   - name: base-values
     files:
+      - alloy-values.yaml=alloy/values.yaml
       - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
       - loki-values.yaml=loki/values.yaml
   - name: base-config
@@ -18,6 +19,7 @@ configurations:
 generatorOptions:
   disableNameSuffixHash: true
 resources:
+  - alloy
   - kube-prometheus-stack
   - loki
   - sources.yaml

--- a/applications/kustomization.yaml
+++ b/applications/kustomization.yaml
@@ -5,6 +5,7 @@ configMapGenerator:
   - name: base-values
     files:
       - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-values.yaml=loki/values.yaml
   - name: base-config
     files:
       - kube-state-metrics-config.yaml=kube-prometheus-stack/metrics.yaml
@@ -18,4 +19,5 @@ generatorOptions:
   disableNameSuffixHash: true
 resources:
   - kube-prometheus-stack
+  - loki
   - sources.yaml

--- a/applications/loki/kustomization.yaml
+++ b/applications/loki/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - release.yaml

--- a/applications/loki/release.yaml
+++ b/applications/loki/release.yaml
@@ -10,7 +10,7 @@ spec:
       chart: loki
       sourceRef:
         kind: HelmRepository
-        name: grafana
+        name: grafana-charts
       version: "6.31.0"
   interval: 10m
   install:

--- a/applications/loki/release.yaml
+++ b/applications/loki/release.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: loki
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+      version: "6.31.0"
+  interval: 10m
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  valuesFrom:
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: loki-values.yaml

--- a/applications/loki/values.yaml
+++ b/applications/loki/values.yaml
@@ -8,6 +8,8 @@ loki:
     - -config.expand-env=true
   limits_config:
     volume_enabled: true
+  pattern_ingester:
+    enabled: true
   # https://grafana.com/docs/loki/latest/configuration/#schema_config
   schemaConfig:
     configs:

--- a/applications/loki/values.yaml
+++ b/applications/loki/values.yaml
@@ -7,6 +7,7 @@ loki:
   extraArgs:
     - -config.expand-env=true
   limits_config:
+    discover_service_name: []
     volume_enabled: true
   pattern_ingester:
     enabled: true

--- a/applications/loki/values.yaml
+++ b/applications/loki/values.yaml
@@ -1,0 +1,30 @@
+# https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
+deploymentMode: SingleBinary
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  extraArgs:
+    - -config.expand-env=true
+  # https://grafana.com/docs/loki/latest/configuration/#schema_config
+  schemaConfig:
+    configs:
+      - from: 2024-04-01
+        index:
+          prefix: index_
+          period: 24h
+        object_store: filesystem
+        schema: v13
+        store: tsdb
+  storage:
+    type: "filesystem"
+chunksCache:
+  allocatedMemory: 2048
+backend:
+  replicas: 0
+read:
+  replicas: 0
+singleBinary:
+  replicas: 1
+write:
+  replicas: 0

--- a/applications/loki/values.yaml
+++ b/applications/loki/values.yaml
@@ -6,6 +6,8 @@ loki:
     replication_factor: 1
   extraArgs:
     - -config.expand-env=true
+  limits_config:
+    volume_enabled: true
   # https://grafana.com/docs/loki/latest/configuration/#schema_config
   schemaConfig:
     configs:

--- a/clusters/azure/production/substitutions/alloy/kustomization.yaml
+++ b/clusters/azure/production/substitutions/alloy/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - release.yaml

--- a/clusters/azure/production/substitutions/alloy/release.yaml
+++ b/clusters/azure/production/substitutions/alloy/release.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: alloy
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+      version: "1.1.2"
+  interval: 10m
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  valuesFrom:
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: alloy-values.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: alloy-values.yaml

--- a/clusters/azure/production/substitutions/alloy/values.yaml
+++ b/clusters/azure/production/substitutions/alloy/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml

--- a/clusters/azure/production/substitutions/kube-prometheus-stack/release.yaml
+++ b/clusters/azure/production/substitutions/kube-prometheus-stack/release.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
@@ -13,15 +14,15 @@ spec:
       version: "71.1.0"
   interval: 10m
   valuesFrom:
-  # Shared/base values for monitoring applications
-  - kind: ConfigMap
-    name: base-values
-    valuesKey: kube-prometheus-stack-values.yaml
-  # Environment-specific values
-  - kind: ConfigMap
-    name: env-values
-    valuesKey: kube-prometheus-stack-values.yaml
-  # Additional configuration for dashboards, metrics, or infrastructure
-  - kind: ConfigMap
-    name: base-config
-    valuesKey: kube-state-metrics-config.yaml
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: kube-prometheus-stack-values.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: kube-prometheus-stack-values.yaml
+    # Additional configuration for dashboards, metrics, or infrastructure
+    - kind: ConfigMap
+      name: base-config
+      valuesKey: kube-state-metrics-config.yaml

--- a/clusters/azure/production/substitutions/kube-prometheus-stack/values.yaml
+++ b/clusters/azure/production/substitutions/kube-prometheus-stack/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml

--- a/clusters/azure/production/substitutions/kustomization.yaml
+++ b/clusters/azure/production/substitutions/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: monitoring
 configMapGenerator:
   - name: env-values
     files:
+      - alloy-values.yaml=alloy/values.yaml
       - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
       - loki-values.yaml=loki/values.yaml
 configurations:
@@ -12,5 +13,6 @@ configurations:
 generatorOptions:
   disableNameSuffixHash: true
 resources:
+  - alloy
   - kube-prometheus-stack
   - loki

--- a/clusters/azure/production/substitutions/kustomization.yaml
+++ b/clusters/azure/production/substitutions/kustomization.yaml
@@ -6,9 +6,11 @@ configMapGenerator:
   - name: env-values
     files:
       - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-values.yaml=loki/values.yaml
 configurations:
   - kustomize.yaml
 generatorOptions:
   disableNameSuffixHash: true
 resources:
   - kube-prometheus-stack
+  - loki

--- a/clusters/azure/production/substitutions/loki/kustomization.yaml
+++ b/clusters/azure/production/substitutions/loki/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - release.yaml

--- a/clusters/azure/production/substitutions/loki/release.yaml
+++ b/clusters/azure/production/substitutions/loki/release.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: loki
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+      version: "6.31.0"
+  interval: 10m
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  valuesFrom:
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: loki-values.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: loki-values.yaml

--- a/clusters/azure/production/substitutions/loki/release.yaml
+++ b/clusters/azure/production/substitutions/loki/release.yaml
@@ -10,7 +10,7 @@ spec:
       chart: loki
       sourceRef:
         kind: HelmRepository
-        name: grafana
+        name: grafana-charts
       version: "6.31.0"
   interval: 10m
   install:

--- a/clusters/azure/production/substitutions/loki/values.yaml
+++ b/clusters/azure/production/substitutions/loki/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml

--- a/clusters/kind/substitutions/alloy/kustomization.yaml
+++ b/clusters/kind/substitutions/alloy/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - release.yaml

--- a/clusters/kind/substitutions/alloy/release.yaml
+++ b/clusters/kind/substitutions/alloy/release.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: alloy
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+      version: "1.1.2"
+  interval: 10m
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  valuesFrom:
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: alloy-values.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: alloy-values.yaml

--- a/clusters/kind/substitutions/alloy/values.yaml
+++ b/clusters/kind/substitutions/alloy/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml

--- a/clusters/kind/substitutions/kube-prometheus-stack/release.yaml
+++ b/clusters/kind/substitutions/kube-prometheus-stack/release.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
@@ -13,15 +14,15 @@ spec:
       version: "71.1.0"
   interval: 10m
   valuesFrom:
-  # Shared/base values for monitoring applications
-  - kind: ConfigMap
-    name: base-values
-    valuesKey: kube-prometheus-stack-values.yaml
-  # Environment-specific values
-  - kind: ConfigMap
-    name: env-values
-    valuesKey: kube-prometheus-stack-values.yaml
-  # Additional configuration for dashboards, metrics, or infrastructure
-  - kind: ConfigMap
-    name: base-config
-    valuesKey: kube-state-metrics-config.yaml
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: kube-prometheus-stack-values.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: kube-prometheus-stack-values.yaml
+    # Additional configuration for dashboards, metrics, or infrastructure
+    - kind: ConfigMap
+      name: base-config
+      valuesKey: kube-state-metrics-config.yaml

--- a/clusters/kind/substitutions/kube-prometheus-stack/values.yaml
+++ b/clusters/kind/substitutions/kube-prometheus-stack/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml

--- a/clusters/kind/substitutions/kustomization.yaml
+++ b/clusters/kind/substitutions/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: monitoring
 configMapGenerator:
   - name: env-values
     files:
+      - alloy-values.yaml=alloy/values.yaml
       - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
       - loki-values.yaml=loki/values.yaml
 configurations:
@@ -12,5 +13,6 @@ configurations:
 generatorOptions:
   disableNameSuffixHash: true
 resources:
+  - alloy
   - kube-prometheus-stack
   - loki

--- a/clusters/kind/substitutions/kustomization.yaml
+++ b/clusters/kind/substitutions/kustomization.yaml
@@ -6,9 +6,11 @@ configMapGenerator:
   - name: env-values
     files:
       - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-values.yaml=loki/values.yaml
 configurations:
   - kustomize.yaml
 generatorOptions:
   disableNameSuffixHash: true
 resources:
   - kube-prometheus-stack
+  - loki

--- a/clusters/kind/substitutions/loki/kustomization.yaml
+++ b/clusters/kind/substitutions/loki/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - release.yaml

--- a/clusters/kind/substitutions/loki/release.yaml
+++ b/clusters/kind/substitutions/loki/release.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: loki
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+      version: "6.31.0"
+  interval: 10m
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  valuesFrom:
+    # Shared/base values for monitoring applications
+    - kind: ConfigMap
+      name: base-values
+      valuesKey: loki-values.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: loki-values.yaml

--- a/clusters/kind/substitutions/loki/release.yaml
+++ b/clusters/kind/substitutions/loki/release.yaml
@@ -10,7 +10,7 @@ spec:
       chart: loki
       sourceRef:
         kind: HelmRepository
-        name: grafana
+        name: grafana-charts
       version: "6.31.0"
   interval: 10m
   install:

--- a/clusters/kind/substitutions/loki/values.yaml
+++ b/clusters/kind/substitutions/loki/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml

--- a/examples/kind/base/flux-system/gotk-sync.yaml
+++ b/examples/kind/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: feature/add_loki_and_promtail
+    branch: main
   url: https://github.com/digicatapult/monitoring-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/examples/kind/base/flux-system/gotk-sync.yaml
+++ b/examples/kind/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: feature/add_loki_and_promtail
   url: https://github.com/digicatapult/monitoring-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/examples/kind/base/sources.yaml
+++ b/examples/kind/base/sources.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: feature/add_loki_and_promtail
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/examples/kind/base/sources.yaml
+++ b/examples/kind/base/sources.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: feature/add_loki_and_promtail
+    branch: main
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/infrastructure/logs/base.alloy
+++ b/infrastructure/logs/base.alloy
@@ -2,27 +2,3 @@ logging {
   level  = "info"
   format = "logfmt"
 }
-
-discovery.kubernetes "pods" {
-  role = "pod"
-}
-
-discovery.kubernetes "nodes" {
-  role = "node"
-}
-
-discovery.kubernetes "services" {
-  role = "service"
-}
-
-discovery.kubernetes "endpoints" {
-  role = "endpoints"
-}
-
-discovery.kubernetes "endpointslices" {
-  role = "endpointslice"
-}
-
-discovery.kubernetes "ingresses" {
-  role = "ingress"
-}

--- a/infrastructure/logs/base.alloy
+++ b/infrastructure/logs/base.alloy
@@ -1,0 +1,28 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+
+discovery.kubernetes "services" {
+  role = "service"
+}
+
+discovery.kubernetes "endpoints" {
+  role = "endpoints"
+}
+
+discovery.kubernetes "endpointslices" {
+  role = "endpointslice"
+}
+
+discovery.kubernetes "ingresses" {
+  role = "ingress"
+}

--- a/infrastructure/logs/kustomization.yaml
+++ b/infrastructure/logs/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+configMapGenerator:
+  - name: logs
+    files:
+      - base.alloy
+    options:
+      labels:
+        app.kubernetes.io/part-of: flux
+        app.kubernetes.io/component: monitoring
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature

## Linked tickets

VR-346

## High level description

Our intention was to implement a Loki stack with Promtail as the agent responsible for shipping logs, but with the planned obsolescence of the latter for March 2026, our plans have since changed. In this PR, we'll be adding a Loki deployment with a Grafana Alloy daemonset instead. This will be integrated with the existing Prometheus stack.

## Detailed description

Loki configuration is typically self-contained within its own values.yaml file, but Alloy requires a ruleset to determine what needs to be discovered and where to trawl for the relevant files. This is optionally included in the values.yaml file, but it can also be broken out on its own, as done here with base.alloy. Our intention is to include multiple rulesets within the `./infrastructure/logs` kustomization, so that specific environments can reference the appropriate set in the relevant overlay.

## Describe alternatives you've considered

Using Promtail until March 2026 is a possibility, but developing and deploying a component just for an eight-month period is far from ideal. Our monitoring infrastructure here is intended to be long-term, generally available, and consistent, so replacing Promtail in the stack seems proportionate.