### PR TITLE
Fix Renovate configuration errors

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -26,11 +26,9 @@ module.exports = (config = {}) => {
     onboarding: false,
     packageRules: [
       {
-        schedule: ["* 9-13,14-17 * * 1-5"],
-      },
-      {
         matchManagers: ["flux"],
         pinDigests: false,
+        schedule: ["* 9-13,14-17 * * 1-5"],
       },
       {
         matchManagers: ["flux"],
@@ -40,7 +38,6 @@ module.exports = (config = {}) => {
         matchPaths: ["applications/.*\\.ya?ml$"],
         separateMajorMinor: true,
         separateMinorPatch: false,
-        separateMultiple: true,
         separateMultipleMajor: true,
       },
       {
@@ -51,7 +48,6 @@ module.exports = (config = {}) => {
         matchPaths: ["clusters/kind/.*\\.ya?ml$"],
         separateMajorMinor: true,
         separateMinorPatch: false,
-        separateMultiple: true,
         separateMultipleMajor: true,
       },
       {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## High level description

One of the configuration options below, `separateMultiple`, was invalid.

Renovate's `packageRules` also requires "match*" or "selector*" in each rule, hence the schedule needs to be bundled with something else generic for the chosen manager.