### PR TITLE
Include non-production paths

### DIFF
--- a/.github/workflows/test-kind.yaml
+++ b/.github/workflows/test-kind.yaml
@@ -10,7 +10,10 @@ on:
     branches:
       - main
     paths:
+      - 'applications/**'
+      - 'clusters/kind/**'
       - 'examples/kind/**'
+      - 'infrastructure/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

We need to expand the list of paths watched so that all of the kustomizations used by the Kind cluster are within scope. Renovate won't currently catch any changes to the application stacks while just watching `./examples/kind`.