### PR TITLE
Add namespaces to HelmRepository sources

### DIFF
--- a/applications/sources.yaml
+++ b/applications/sources.yaml
@@ -3,6 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: digicatapult
+  namespace: monitoring
 spec:
   interval: 10m
   url: https://digicatapult.github.io/helm-charts
@@ -11,6 +12,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana-charts
+  namespace: monitoring
 spec:
   interval: 10m
   url: https://grafana.github.io/helm-charts
@@ -19,6 +21,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-community
+  namespace: monitoring
 spec:
   interval: 10m
   type: oci


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## High level description

Renovate requires sources to have a namespace. Without it, the bot will skip the registry:

```
           {
             "packageFile": "applications/alloy/release.yaml",
             "deps": [
               {
                 "depName": "alloy",
                 "currentValue": "1.1.2",
                 "datasource": "helm",
                 "skipReason": "unknown-registry",
                 "updates": [],
                 "packageName": "alloy"
               }
             ]
           },
```