### PR TITLE
Fix Renovate auto-merging

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -36,7 +36,11 @@ module.exports = (config = {}) => {
         addLabels: ["automerge", "base"],
         automerge: true,
         groupName: "flux - base layer",
-        matchFileNames: ["applications/.*\\.ya?ml$"],
+        matchFileNames: [
+          "applications/**/*.yaml",
+          "applications/**/*.yml"
+        ],
+        matchUpdateTypes: ["minor", "patch", "pin", "digest"],
         separateMajorMinor: true,
         separateMinorPatch: false,
         separateMultipleMajor: true,
@@ -46,7 +50,11 @@ module.exports = (config = {}) => {
         addLabels: ["automerge", "kind"],
         automerge: true,
         groupName: "flux - kind overlay",
-        matchFileNames: ["clusters/kind/.*\\.ya?ml$"],
+        matchFileNames: [
+          "clusters/kind/**/*.yaml",
+          "clusters/kind/**/*.yml"
+        ],
+        matchUpdateTypes: ["minor", "patch", "pin", "digest"],
         separateMajorMinor: true,
         separateMinorPatch: false,
         separateMultipleMajor: true,
@@ -66,7 +74,10 @@ module.exports = (config = {}) => {
       {
         matchManagers: ["flux"],
         enabled: false,
-        matchFileNames: ["clusters/azure/.*\\.ya?ml$"],
+        matchFileNames: [
+          "clusters/azure/**/*.yaml",
+          "clusters/azure/**/*.yml"
+        ],
       },
     ],
     prHourlyLimit: 20,


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

ENG-177/VR-345

## High level description

Our Renovate configuration was missing a specific field to enable auto-merging against the repository; `matchUpdateTypes` provides the fix. Separately, I changed the glob format in `matchFileNames` so that the style is more consistent throughout the configuration.

Anything else blocking the auto-merging will be specific repository settings, rather than Renovate.