### PR TITLE
Add missing secret reference for Grafana

### DIFF
--- a/clusters/azure/production/substitutions/kube-prometheus-stack/release.yaml
+++ b/clusters/azure/production/substitutions/kube-prometheus-stack/release.yaml
@@ -26,3 +26,8 @@ spec:
     - kind: ConfigMap
       name: base-config
       valuesKey: kube-state-metrics-config.yaml
+    # Encrypted secrets for the project
+    - kind: Secret
+      name: monitoring-secrets
+      valuesKey: grafana_password
+      targetPath: grafana.adminPassword


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

VR-345

## High level description

I previously omitted the secret we use to access the monitoring interface.

## Operational impact

This will require us to use the same name for similar secrets across all of our projects' monitoring stacks. Those secrets will reside in the project repositories and they should all be unique.