### PR TITLE
Support project-specific overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Some attention needs to be given to the precedence of values; the last values fi
   valuesFrom:
     - kind: ConfigMap
       name: base-values
-      valuesKey: kube-prometheus-stack-values.yaml
+      valuesKey: kube-prometheus-stack-base-values.yaml
     - kind: ConfigMap
       name: env-values
-      valuesKey: kube-prometheus-stack-values.yaml
+      valuesKey: kube-prometheus-stack-env-values.yaml
 ```
 
 To provide an example of the above, there could be relevant values files in three separate locations:

--- a/applications/alloy/release.yaml
+++ b/applications/alloy/release.yaml
@@ -22,7 +22,11 @@ spec:
     - kind: ConfigMap
       name: base-values
       valuesKey: alloy-base-values.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: alloy-env-values.yaml
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: alloy-project-values.yaml

--- a/applications/alloy/release.yaml
+++ b/applications/alloy/release.yaml
@@ -21,4 +21,8 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: alloy-values.yaml
+      valuesKey: alloy-base-values.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: alloy-env-values.yaml

--- a/applications/kube-prometheus-stack/release.yaml
+++ b/applications/kube-prometheus-stack/release.yaml
@@ -28,8 +28,12 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: kube-prometheus-stack-values.yaml
+      valuesKey: kube-prometheus-stack-base-values.yaml
     # Additional configuration for dashboards, metrics, or infrastructure
     - kind: ConfigMap
       name: base-config
-      valuesKey: kube-state-metrics-config.yaml
+      valuesKey: kube-state-metrics-base-config.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: kube-prometheus-stack-env-values.yaml

--- a/applications/kube-prometheus-stack/release.yaml
+++ b/applications/kube-prometheus-stack/release.yaml
@@ -33,7 +33,11 @@ spec:
     - kind: ConfigMap
       name: base-config
       valuesKey: kube-state-metrics-base-config.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: kube-prometheus-stack-env-values.yaml
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: kube-prometheus-stack-project-values.yaml

--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -34,7 +34,6 @@ grafana:
       type: camptocamp-prometheus-alertmanager-datasource
       uid: prometheus-alertmanager
       url: http://{{ template "kube-prometheus-stack.fullname" . }}-alertmanager.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.alertmanager.service.port }}/{{ trimPrefix "/" .Values.alertmanager.alertmanagerSpec.routePrefix }}
-  adminPassword: grafana
   dashboards:
     default:
       alertmanager:

--- a/applications/kustomization.yaml
+++ b/applications/kustomization.yaml
@@ -4,12 +4,12 @@ namespace: monitoring
 configMapGenerator:
   - name: base-values
     files:
-      - alloy-values.yaml=alloy/values.yaml
-      - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
-      - loki-values.yaml=loki/values.yaml
+      - alloy-base-values.yaml=alloy/values.yaml
+      - kube-prometheus-stack-base-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-base-values.yaml=loki/values.yaml
   - name: base-config
     files:
-      - kube-state-metrics-config.yaml=kube-prometheus-stack/metrics.yaml
+      - kube-state-metrics-base-config.yaml=kube-prometheus-stack/metrics.yaml
     options:
       labels:
         app.kubernetes.io/part-of: flux

--- a/applications/loki/release.yaml
+++ b/applications/loki/release.yaml
@@ -22,7 +22,11 @@ spec:
     - kind: ConfigMap
       name: base-values
       valuesKey: loki-base-values.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: loki-env-values.yaml
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: loki-project-values.yaml

--- a/applications/loki/release.yaml
+++ b/applications/loki/release.yaml
@@ -21,4 +21,8 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: loki-values.yaml
+      valuesKey: loki-base-values.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: loki-env-values.yaml

--- a/clusters/azure/production/substitutions/alloy/release.yaml
+++ b/clusters/azure/production/substitutions/alloy/release.yaml
@@ -22,7 +22,11 @@ spec:
     - kind: ConfigMap
       name: base-values
       valuesKey: alloy-base-values.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: alloy-env-values.yaml
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: alloy-project-values.yaml

--- a/clusters/azure/production/substitutions/alloy/release.yaml
+++ b/clusters/azure/production/substitutions/alloy/release.yaml
@@ -21,8 +21,8 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: alloy-values.yaml
+      valuesKey: alloy-base-values.yaml
     # Environment-specific values
     - kind: ConfigMap
       name: env-values
-      valuesKey: alloy-values.yaml
+      valuesKey: alloy-env-values.yaml

--- a/clusters/azure/production/substitutions/kube-prometheus-stack/release.yaml
+++ b/clusters/azure/production/substitutions/kube-prometheus-stack/release.yaml
@@ -17,15 +17,15 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: kube-prometheus-stack-values.yaml
-    # Environment-specific values
-    - kind: ConfigMap
-      name: env-values
-      valuesKey: kube-prometheus-stack-values.yaml
+      valuesKey: kube-prometheus-stack-base-values.yaml
     # Additional configuration for dashboards, metrics, or infrastructure
     - kind: ConfigMap
       name: base-config
-      valuesKey: kube-state-metrics-config.yaml
+      valuesKey: kube-state-metrics-base-config.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: kube-prometheus-stack-env-values.yaml
     # Encrypted secrets for the project
     - kind: Secret
       name: monitoring-secrets

--- a/clusters/azure/production/substitutions/kube-prometheus-stack/release.yaml
+++ b/clusters/azure/production/substitutions/kube-prometheus-stack/release.yaml
@@ -22,7 +22,7 @@ spec:
     - kind: ConfigMap
       name: base-config
       valuesKey: kube-state-metrics-base-config.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: kube-prometheus-stack-env-values.yaml
@@ -31,3 +31,7 @@ spec:
       name: monitoring-secrets
       valuesKey: grafana_password
       targetPath: grafana.adminPassword
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: kube-prometheus-stack-project-values.yaml

--- a/clusters/azure/production/substitutions/kube-prometheus-stack/values.yaml
+++ b/clusters/azure/production/substitutions/kube-prometheus-stack/values.yaml
@@ -39,11 +39,6 @@ grafana:
   ingress:
     enabled: true
     ingressClassName: nginx-monitoring
-    hosts:
-      - "${MONITORING_STACK_HOSTNAME}"
-  grafana.ini:
-    server:
-      root_url: "${MONITORING_STACK_URL}"
   persistence:
     accessModes:
       - ReadWriteOnce

--- a/clusters/azure/production/substitutions/kustomization.yaml
+++ b/clusters/azure/production/substitutions/kustomization.yaml
@@ -5,9 +5,9 @@ namespace: monitoring
 configMapGenerator:
   - name: env-values
     files:
-      - alloy-values.yaml=alloy/values.yaml
-      - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
-      - loki-values.yaml=loki/values.yaml
+      - alloy-env-values.yaml=alloy/values.yaml
+      - kube-prometheus-stack-env-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-env-values.yaml=loki/values.yaml
 configurations:
   - kustomize.yaml
 generatorOptions:

--- a/clusters/azure/production/substitutions/loki/release.yaml
+++ b/clusters/azure/production/substitutions/loki/release.yaml
@@ -21,8 +21,8 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: loki-values.yaml
+      valuesKey: loki-base-values.yaml
     # Environment-specific values
     - kind: ConfigMap
       name: env-values
-      valuesKey: loki-values.yaml
+      valuesKey: loki-env-values.yaml

--- a/clusters/azure/production/substitutions/loki/release.yaml
+++ b/clusters/azure/production/substitutions/loki/release.yaml
@@ -22,7 +22,11 @@ spec:
     - kind: ConfigMap
       name: base-values
       valuesKey: loki-base-values.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: loki-env-values.yaml
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: loki-project-values.yaml

--- a/clusters/kind/substitutions/alloy/release.yaml
+++ b/clusters/kind/substitutions/alloy/release.yaml
@@ -22,7 +22,11 @@ spec:
     - kind: ConfigMap
       name: base-values
       valuesKey: alloy-base-values.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: alloy-env-values.yaml
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: alloy-project-values.yaml

--- a/clusters/kind/substitutions/alloy/release.yaml
+++ b/clusters/kind/substitutions/alloy/release.yaml
@@ -21,8 +21,8 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: alloy-values.yaml
+      valuesKey: alloy-base-values.yaml
     # Environment-specific values
     - kind: ConfigMap
       name: env-values
-      valuesKey: alloy-values.yaml
+      valuesKey: alloy-env-values.yaml

--- a/clusters/kind/substitutions/kube-prometheus-stack/release.yaml
+++ b/clusters/kind/substitutions/kube-prometheus-stack/release.yaml
@@ -17,12 +17,12 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: kube-prometheus-stack-values.yaml
-    # Environment-specific values
-    - kind: ConfigMap
-      name: env-values
-      valuesKey: kube-prometheus-stack-values.yaml
+      valuesKey: kube-prometheus-stack-base-values.yaml
     # Additional configuration for dashboards, metrics, or infrastructure
     - kind: ConfigMap
       name: base-config
-      valuesKey: kube-state-metrics-config.yaml
+      valuesKey: kube-state-metrics-base-config.yaml
+    # Environment-specific values
+    - kind: ConfigMap
+      name: env-values
+      valuesKey: kube-prometheus-stack-env-values.yaml

--- a/clusters/kind/substitutions/kube-prometheus-stack/release.yaml
+++ b/clusters/kind/substitutions/kube-prometheus-stack/release.yaml
@@ -22,7 +22,11 @@ spec:
     - kind: ConfigMap
       name: base-config
       valuesKey: kube-state-metrics-base-config.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: kube-prometheus-stack-env-values.yaml
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: kube-prometheus-stack-project-values.yaml

--- a/clusters/kind/substitutions/kustomization.yaml
+++ b/clusters/kind/substitutions/kustomization.yaml
@@ -5,9 +5,9 @@ namespace: monitoring
 configMapGenerator:
   - name: env-values
     files:
-      - alloy-values.yaml=alloy/values.yaml
-      - kube-prometheus-stack-values.yaml=kube-prometheus-stack/values.yaml
-      - loki-values.yaml=loki/values.yaml
+      - alloy-env-values.yaml=alloy/values.yaml
+      - kube-prometheus-stack-env-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-env-values.yaml=loki/values.yaml
 configurations:
   - kustomize.yaml
 generatorOptions:

--- a/clusters/kind/substitutions/loki/release.yaml
+++ b/clusters/kind/substitutions/loki/release.yaml
@@ -21,8 +21,8 @@ spec:
     # Shared/base values for monitoring applications
     - kind: ConfigMap
       name: base-values
-      valuesKey: loki-values.yaml
+      valuesKey: loki-base-values.yaml
     # Environment-specific values
     - kind: ConfigMap
       name: env-values
-      valuesKey: loki-values.yaml
+      valuesKey: loki-env-values.yaml

--- a/clusters/kind/substitutions/loki/release.yaml
+++ b/clusters/kind/substitutions/loki/release.yaml
@@ -22,7 +22,11 @@ spec:
     - kind: ConfigMap
       name: base-values
       valuesKey: loki-base-values.yaml
-    # Environment-specific values
+    # Environment-type values
     - kind: ConfigMap
       name: env-values
       valuesKey: loki-env-values.yaml
+    # Project values
+    - kind: ConfigMap
+      name: project-values
+      valuesKey: loki-project-values.yaml

--- a/examples/azure/production/base/env-sync.yaml
+++ b/examples/azure/production/base/env-sync.yaml
@@ -5,6 +5,9 @@ metadata:
   name: env-sync
   namespace: monitoring
 spec:
+  dependsOn:
+    - name: project-sync
+      namespace: monitoring
   interval: 10m0s
   path: ./clusters/azure/production
   prune: true

--- a/examples/azure/production/base/monitoring-sync.yaml
+++ b/examples/azure/production/base/monitoring-sync.yaml
@@ -5,6 +5,9 @@ metadata:
   name: monitoring-sync
   namespace: monitoring
 spec:
+  dependsOn:
+    - name: project-sync
+      namespace: monitoring
   interval: 10m0s
   path: ./applications
   prune: true

--- a/examples/azure/production/base/project-sync.yaml
+++ b/examples/azure/production/base/project-sync.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: project-sync
+  namespace: monitoring
+spec:
+  interval: 10m0s
+  path: ./examples/azure/production/monitoring
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/examples/azure/production/base/sources.yaml
+++ b/examples/azure/production/base/sources.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: bug/triage_configmap_order
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/examples/azure/production/base/sources.yaml
+++ b/examples/azure/production/base/sources.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: bug/triage_configmap_order
+    branch: main
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/examples/azure/production/monitoring/alloy/kustomization.yaml
+++ b/examples/azure/production/monitoring/alloy/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/examples/azure/production/monitoring/alloy/values.yaml
+++ b/examples/azure/production/monitoring/alloy/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml

--- a/examples/azure/production/monitoring/kube-prometheus-stack/kustomization.yaml
+++ b/examples/azure/production/monitoring/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/examples/azure/production/monitoring/kube-prometheus-stack/values.yaml
+++ b/examples/azure/production/monitoring/kube-prometheus-stack/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml

--- a/examples/azure/production/monitoring/kustomization.yaml
+++ b/examples/azure/production/monitoring/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+configMapGenerator:
+  - name: project-values
+    files:
+      - alloy-project-values.yaml=alloy/values.yaml
+      - kube-prometheus-stack-project-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-project-values.yaml=loki/values.yaml
+configurations:
+  - kustomize.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - alloy
+  - kube-prometheus-stack
+  - loki

--- a/examples/azure/production/monitoring/kustomize.yaml
+++ b/examples/azure/production/monitoring/kustomize.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+- kind: ConfigMap
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease
+  version: v1

--- a/examples/azure/production/monitoring/loki/kustomization.yaml
+++ b/examples/azure/production/monitoring/loki/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/examples/azure/production/monitoring/loki/values.yaml
+++ b/examples/azure/production/monitoring/loki/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml

--- a/examples/kind/base/env-sync.yaml
+++ b/examples/kind/base/env-sync.yaml
@@ -5,6 +5,9 @@ metadata:
   name: env-sync
   namespace: monitoring
 spec:
+  dependsOn:
+    - name: project-sync
+      namespace: monitoring
   interval: 10m0s
   path: ./clusters/kind
   prune: true

--- a/examples/kind/base/flux-system/gotk-sync.yaml
+++ b/examples/kind/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: bug/triage_configmap_order
   url: https://github.com/digicatapult/monitoring-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/examples/kind/base/flux-system/gotk-sync.yaml
+++ b/examples/kind/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: bug/triage_configmap_order
+    branch: main
   url: https://github.com/digicatapult/monitoring-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/examples/kind/base/monitoring-sync.yaml
+++ b/examples/kind/base/monitoring-sync.yaml
@@ -5,6 +5,9 @@ metadata:
   name: monitoring-sync
   namespace: monitoring
 spec:
+  dependsOn:
+    - name: project-sync
+      namespace: monitoring
   interval: 10m0s
   path: ./applications
   prune: true

--- a/examples/kind/base/project-sync.yaml
+++ b/examples/kind/base/project-sync.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: project-sync
+  namespace: monitoring
+spec:
+  interval: 10m0s
+  path: ./examples/kind/monitoring
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/examples/kind/base/sources.yaml
+++ b/examples/kind/base/sources.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: bug/triage_configmap_order
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/examples/kind/base/sources.yaml
+++ b/examples/kind/base/sources.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: bug/triage_configmap_order
+    branch: main
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/examples/kind/monitoring/alloy/kustomization.yaml
+++ b/examples/kind/monitoring/alloy/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/examples/kind/monitoring/alloy/values.yaml
+++ b/examples/kind/monitoring/alloy/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml

--- a/examples/kind/monitoring/kube-prometheus-stack/kustomization.yaml
+++ b/examples/kind/monitoring/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/examples/kind/monitoring/kube-prometheus-stack/values.yaml
+++ b/examples/kind/monitoring/kube-prometheus-stack/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml

--- a/examples/kind/monitoring/kube-prometheus-stack/values.yaml
+++ b/examples/kind/monitoring/kube-prometheus-stack/values.yaml
@@ -1,1 +1,4 @@
 # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
+prometheus:
+  prometheusSpec:
+    retention: 12h

--- a/examples/kind/monitoring/kustomization.yaml
+++ b/examples/kind/monitoring/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+configMapGenerator:
+  - name: project-values
+    files:
+      - alloy-project-values.yaml=alloy/values.yaml
+      - kube-prometheus-stack-project-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-project-values.yaml=loki/values.yaml
+configurations:
+  - kustomize.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - alloy
+  - kube-prometheus-stack
+  - loki

--- a/examples/kind/monitoring/kustomize.yaml
+++ b/examples/kind/monitoring/kustomize.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+- kind: ConfigMap
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease
+  version: v1

--- a/examples/kind/monitoring/loki/kustomization.yaml
+++ b/examples/kind/monitoring/loki/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/examples/kind/monitoring/loki/values.yaml
+++ b/examples/kind/monitoring/loki/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

VR-408

## High level description

We have two abstract layers currently within the monitoring stack, but need a third to sit within the project repository and provide the granular detail that can’t be included externally in the abstractions here. It’s this third layer, notionally via the ConfigMap “project-values”, which will be providing endpoints, ports, URIs, and any other specifics.

It’s suggested that we have the following ConfigMaps in order of precedence:

1. “project-values” (the individual project)
2. “env-values” (all environments of a given type)
3. “base-values” (all shared applications)

## Describe alternatives you've considered

Having just two layers might also suffice, but still encourages more duplication downstream. Base values could be provided in this repository, while each project overlays those with its own values in its repository.

## Operational impact

This will be a breaking change, so downstream sources will need to be patched to track the next major version (v3) of the stack and include values specific to the project.

## Additional context

This sample within the Kind example directory is known to work:
```yaml
prometheus:
  prometheusSpec:
    retention: 12h
```
