### PR TITLE
Remove duplicate line to fix parsing

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -28,7 +28,6 @@ module.exports = (config = {}) => {
     ],
     onboarding: false,
     packageRules: [
-    packageRules: [
       {
         matchManagers: ["github-actions"],
         matchPackageNames: ["helm/kind-action"],


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## High level description

A duplicate `packageRules` line breaks JSON parsing.